### PR TITLE
only show cart if matching cart id is in session

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,7 @@
 
 /app/assets/builds/*
 !/app/assets/builds/.keep
+
+# Ignore VIM swap files
+*.swp
+*.swo

--- a/app/controllers/carts_controller.rb
+++ b/app/controllers/carts_controller.rb
@@ -9,6 +9,7 @@ class CartsController < ApplicationController
 
   # GET /carts/1 or /carts/1.json
   def show
+    redirect_to store_index_url unless session[:cart_id] == @cart.id
   end
 
   # GET /carts/new
@@ -26,6 +27,7 @@ class CartsController < ApplicationController
 
     respond_to do |format|
       if @cart.save
+        session[:cart_id] = @cart.id
         format.html { redirect_to cart_url(@cart), notice: "Cart was successfully created." }
         format.json { render :show, status: :created, location: @cart }
       else

--- a/test/controllers/carts_controller_test.rb
+++ b/test/controllers/carts_controller_test.rb
@@ -23,9 +23,29 @@ class CartsControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to cart_url(Cart.last)
   end
 
-  test "should show cart" do
-    get cart_url(@cart)
+  test 'should show cart' do
+    assert_difference('Cart.count') do
+      post carts_url, params: { cart: { } }
+    end
+    
+    follow_redirect!
+
+    my_cart = Cart.last
+
+    get cart_url(my_cart.id)
     assert_response :success
+  end
+  
+  test 'should not show cart if cart id is not in session' do
+    another_cart = carts(:two)
+    assert_difference('Cart.count') do
+      post carts_url
+    end
+
+    follow_redirect!
+
+    get cart_url(another_cart.id)
+    assert_redirected_to store_index_url
   end
 
   test "should get edit" do


### PR DESCRIPTION
- Implements one of the "playtime" challenges from the end of "Iteration E3 : Finishing the Cart"
  - Specifically, it prevents users from viewing a cart where the `cart.id` doesn't match the `cart_id` stored in the session.