### PR TITLE
Use TurboStream to remove empty cart

### DIFF
--- a/app/controllers/carts_controller.rb
+++ b/app/controllers/carts_controller.rb
@@ -56,6 +56,13 @@ class CartsController < ApplicationController
     session[:cart_id] = nil
 
     respond_to do |format|
+      format.turbo_stream do
+        render turbo_stream: turbo_stream.replace(
+          :cart,
+          partial: 'layouts/cart',
+          locals: { cart: nil }
+        )
+      end
       format.html { redirect_to store_index_url,  notice: 'Your cart is currently empty' }
       format.json { head :no_content }
     end

--- a/test/controllers/carts_controller_test.rb
+++ b/test/controllers/carts_controller_test.rb
@@ -68,4 +68,17 @@ class CartsControllerTest < ActionDispatch::IntegrationTest
   
     assert_redirected_to store_index_url  
   end
+
+  test 'should destroy cart and respond with turbo stream without redirecting' do
+    post line_items_url, params: { product_id: products(:ruby).id }
+    @cart = Cart.find(session[:cart_id])
+
+    assert_difference('Cart.count', -1) do
+      delete cart_url(@cart), as: :turbo_stream
+    end
+  
+    assert_response :success
+
+    assert_select 'turbo-stream[action=replace][target=cart]'
+  end
 end


### PR DESCRIPTION
- One of the challenges at the end of the "Iteration F4: Broadcasting Updates with Action Cable" section of the book.
- Uses TurboStream to remove the cart from the UI if it is emptied, rather than following a redirect to reload the entire page.